### PR TITLE
Add reusable Back to Dashboard button component

### DIFF
--- a/src/app/workout/[id]/WorkoutClient.tsx
+++ b/src/app/workout/[id]/WorkoutClient.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { ArrowLeft, Edit, Save, Trash2, Play, Clock, Calendar, CheckCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { BackToDashboardButton } from '@/components/BackToDashboardButton'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle, CardFooter } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -124,20 +125,14 @@ export default function WorkoutClient({ workoutData }: WorkoutClientProps) {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        {/* Back to Dashboard */}
+        <BackToDashboardButton />
+
         {/* Header */}
         <Card className="mb-6">
           <CardHeader>
             <div className="flex items-center justify-between">
-              <div className="flex items-center gap-4">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => router.push('/dashboard')}
-                >
-                  <ArrowLeft className="w-4 h-4" />
-                  Back to Dashboard
-                </Button>
-                <div>
+              <div>
                   <CardTitle className="flex items-center gap-2">
                     {isEditing ? (
                       <Input
@@ -174,7 +169,6 @@ export default function WorkoutClient({ workoutData }: WorkoutClientProps) {
                     )}
                   </CardDescription>
                 </div>
-              </div>
 
               <div className="flex items-center gap-2">
                 {!isCompleted && !isEditing && (

--- a/src/app/workout/new/NewWorkoutClient.tsx
+++ b/src/app/workout/new/NewWorkoutClient.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { CalendarDays, Clock, Save, ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { BackToDashboardButton } from "@/components/BackToDashboardButton";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -84,21 +85,14 @@ export default function NewWorkoutClient({ userId, selectedDate }: NewWorkoutCli
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        {/* Back to Dashboard */}
+        <BackToDashboardButton />
+
         {/* Header */}
         <Card className="mb-6">
           <CardHeader>
             <div className="flex items-center justify-between">
-              <div className="flex items-center gap-4">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => router.push("/dashboard")}
-                >
-                  <ArrowLeft className="w-4 h-4" />
-                  Back to Dashboard
-                </Button>
-                <CardTitle>Log New Workout</CardTitle>
-              </div>
+              <CardTitle>Log New Workout</CardTitle>
               <Button
                 onClick={handleSaveWorkout}
                 disabled={isPending || !title.trim()}

--- a/src/components/BackToDashboardButton.tsx
+++ b/src/components/BackToDashboardButton.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+export function BackToDashboardButton() {
+  const router = useRouter();
+
+  return (
+    <Card className="mb-6">
+      <CardContent className="pt-6">
+        <Button
+          variant="default"
+          size="sm"
+          onClick={() => router.push("/dashboard")}
+          aria-label="Navigate back to workout dashboard"
+          className="transition-all duration-300 hover:scale-105"
+        >
+          <ArrowLeft className="w-4 h-4 mr-2" aria-hidden="true" />
+          Back to Dashboard
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
- Create BackToDashboardButton component with Card layout
- Style button to match Complete button (black background, white text)
- Add to both workout pages (new and edit/details)
- Remove inline back buttons from page headers
- Add hover animation (scale 105%)
- Use default variant and small size for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Repositioned the "Back to Dashboard" button from the header to above it across workout pages for improved visual hierarchy.

* **Style**
  * Added subtle hover scale transition effect to the navigation button.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->