### PR TITLE
fix: preserve selected date when navigating from edit page to dashboard

### DIFF
--- a/src/app/workout/[id]/WorkoutClient.tsx
+++ b/src/app/workout/[id]/WorkoutClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
+import { format } from 'date-fns'
 import { ArrowLeft, Edit, Save, Trash2, Play, Clock, Calendar, CheckCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { BackToDashboardButton } from '@/components/BackToDashboardButton'
@@ -86,8 +87,9 @@ export default function WorkoutClient({ workoutData }: WorkoutClientProps) {
         const result = await deleteWorkoutAction(workout.id)
 
         if (result.success) {
-          // Redirect to dashboard after successful deletion
-          router.push('/dashboard')
+          // Redirect to dashboard with the workout's date after successful deletion
+          const formattedDate = format(workout.startedAt, "yyyy-MM-dd")
+          router.push(`/dashboard?date=${formattedDate}`)
         } else {
           alert('Failed to delete workout')
           setIsNavigating(false)
@@ -142,7 +144,10 @@ export default function WorkoutClient({ workoutData }: WorkoutClientProps) {
       <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
         {/* Back to Dashboard */}
-        <BackToDashboardButton onNavigate={() => setIsNavigating(true)} />
+        <BackToDashboardButton
+          onNavigate={() => setIsNavigating(true)}
+          workoutDate={workout.startedAt}
+        />
 
         {/* Header */}
         <Card className="mb-6">

--- a/src/components/BackToDashboardButton.tsx
+++ b/src/components/BackToDashboardButton.tsx
@@ -1,22 +1,31 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { format } from "date-fns";
 import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 
 interface BackToDashboardButtonProps {
   onNavigate?: () => void;
+  workoutDate?: Date;
 }
 
-export function BackToDashboardButton({ onNavigate }: BackToDashboardButtonProps) {
+export function BackToDashboardButton({ onNavigate, workoutDate }: BackToDashboardButtonProps) {
   const router = useRouter();
 
   const handleNavigationWithLoading = () => {
     if (onNavigate) {
       onNavigate();
     }
-    router.push("/dashboard");
+
+    // If workoutDate is provided, navigate to dashboard with date parameter
+    if (workoutDate) {
+      const formattedDate = format(workoutDate, "yyyy-MM-dd");
+      router.push(`/dashboard?date=${formattedDate}`);
+    } else {
+      router.push("/dashboard");
+    }
   };
 
   return (


### PR DESCRIPTION
- Updated BackToDashboardButton to accept workoutDate prop
- Pass workout date as URL parameter when navigating to dashboard
- Also preserve date after workout deletion
- Fixes issue where calendar date reset to today after editing

Fixes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Dashboard navigation now preserves the workout date when returning after deletion, improving the user's navigation experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->