### PR TITLE
fix: reduce loader overlay size

### DIFF
--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -16,14 +16,14 @@ export function LoadingOverlay({ isLoading }: LoadingOverlayProps) {
       >
         <DialogTitle className="sr-only">Loading</DialogTitle>
         <div
-          className="flex flex-col items-center gap-4 p-8 bg-white dark:bg-gray-800 rounded-lg shadow-xl"
+          className="flex flex-col items-center gap-2 p-4 bg-white dark:bg-gray-800 rounded-lg shadow-xl"
           role="status"
           aria-live="polite"
         >
-          <Loader2 className="h-16 w-16 animate-spin text-pink-600 dark:text-pink-400" />
+          <Loader2 className="h-8 w-8 animate-spin text-pink-600 dark:text-pink-400" />
           <p
             id="loading-description"
-            className="text-lg font-semibold text-gray-900 dark:text-white"
+            className="text-sm font-semibold text-gray-900 dark:text-white"
           >
             Loading...
           </p>


### PR DESCRIPTION
## Summary

Reduced the size of the LoadingOverlay component to make it less intrusive:
- Spinner size: h-16 w-16 → h-8 w-8 (50% smaller)
- Padding: p-8 → p-4 (50% smaller)
- Gap: gap-4 → gap-2 (50% smaller)
- Text size: text-lg → text-sm

The loader overlay is now much more compact while maintaining good visibility and accessibility.

Fixes #15

---

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the loading overlay UI with reduced spacing and more compact sizing for a streamlined appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->