### PR TITLE
fix: display dates/times in client local timezone instead of UTC

### DIFF
--- a/src/app/dashboard/DashboardClient.tsx
+++ b/src/app/dashboard/DashboardClient.tsx
@@ -155,7 +155,7 @@ export default function DashboardClient({
 
         {/* Workouts List */}
         <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4" suppressHydrationWarning>
             Workouts for {formatDateWithOrdinal(displayDate)}
           </h2>
 
@@ -183,9 +183,9 @@ export default function DashboardClient({
                       {workout.title}
                     </h3>
                     <div className="flex items-center gap-4 text-sm text-gray-600 dark:text-gray-400">
-                      <span>Started: {formatTimestampForDisplay(workout.startedAt, "h:mm a")}</span>
+                      <span suppressHydrationWarning>Started: {formatTimestampForDisplay(workout.startedAt, "h:mm a")}</span>
                       {workout.completedAt && (
-                        <span>
+                        <span suppressHydrationWarning>
                           Completed: {formatTimestampForDisplay(workout.completedAt, "h:mm a")}
                         </span>
                       )}

--- a/src/app/workout/[id]/WorkoutClient.tsx
+++ b/src/app/workout/[id]/WorkoutClient.tsx
@@ -175,11 +175,11 @@ export default function WorkoutClient({ workoutData }: WorkoutClientProps) {
                     )}
                   </CardTitle>
                   <CardDescription className="flex items-center gap-4 mt-1">
-                    <div className="flex items-center gap-1">
+                    <div className="flex items-center gap-1" suppressHydrationWarning>
                       <Calendar className="w-4 h-4" />
                       {formatDateWithOrdinal(workout.startedAt)}
                     </div>
-                    <div className="flex items-center gap-1">
+                    <div className="flex items-center gap-1" suppressHydrationWarning>
                       <Clock className="w-4 h-4" />
                       {formatTimestampForDisplay(workout.startedAt, 'h:mm a')}
                     </div>
@@ -425,7 +425,7 @@ export default function WorkoutClient({ workoutData }: WorkoutClientProps) {
                 <CheckCircle className="w-5 h-5" />
                 <span className="font-semibold">Workout Completed</span>
               </div>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1" suppressHydrationWarning>
                 Completed on {formatDateWithOrdinal(workout.completedAt)} at {formatTimestampForDisplay(workout.completedAt, 'h:mm a')}
                 {workout.durationMinutes && (
                   <>

--- a/src/app/workout/new/NewWorkoutClient.tsx
+++ b/src/app/workout/new/NewWorkoutClient.tsx
@@ -46,19 +46,24 @@ export default function NewWorkoutClient({ userId, selectedDate }: NewWorkoutCli
 
     startTransition(async () => {
       try {
-        // Format date as YYYY-MM-DD for proper parsing
-        const formattedDate = workoutDate.getFullYear() + '-' +
-          String(workoutDate.getMonth() + 1).padStart(2, '0') + '-' +
-          String(workoutDate.getDate()).padStart(2, '0');
-
-        console.log('Formatted date for action:', formattedDate);
-        console.log('Start time for action:', startTime);
+        // Build a Date in the user's local timezone using the selected date and time,
+        // then convert to a UTC ISO string so the server stores the correct moment.
+        const [hours, minutes] = startTime.split(':').map(Number);
+        const localDateTime = new Date(
+          workoutDate.getFullYear(),
+          workoutDate.getMonth(),
+          workoutDate.getDate(),
+          hours,
+          minutes,
+          0,
+          0
+        );
+        const startedAtISO = localDateTime.toISOString();
 
         const result = await createWorkoutAction({
           title: title.trim(),
           notes: notes.trim() || undefined,
-          workoutDate: formattedDate,
-          startTime: startTime, // Send the time as selected by user (defaults to current time)
+          startedAtISO,
         });
 
         if (result.success && result.redirectDate) {

--- a/src/app/workout/new/action.ts
+++ b/src/app/workout/new/action.ts
@@ -9,52 +9,24 @@ import { format } from 'date-fns'
 const CreateWorkoutSchema = z.object({
   title: z.string().min(1, 'Title is required').max(100),
   notes: z.string().optional(),
-  startTime: z.string().optional(),
-  workoutDate: z.string().min(1, 'Date is required'),
+  // UTC ISO string computed in the browser (preserves user's local timezone)
+  startedAtISO: z.string().min(1, 'Start datetime is required'),
 })
 
 export async function createWorkoutAction(data: z.infer<typeof CreateWorkoutSchema>) {
-  console.log('Action called with data:', data)
-
   try {
     // Validate input data
     const validatedData = CreateWorkoutSchema.parse(data)
-    console.log('Validation passed:', validatedData)
 
     // Get authenticated user
     const { userId } = await auth()
-    console.log('User ID:', userId)
 
     if (!userId) {
       throw new Error('User not authenticated')
     }
 
-    // Parse workout date and create proper datetime with timezone preservation
-    // The workoutDate should be in YYYY-MM-DD format from the date picker
-    let startedAt: Date
-
-    if (validatedData.startTime) {
-      // Combine date and time properly to preserve local timezone
-      const [hours, minutes] = validatedData.startTime.split(':')
-      const [year, month, day] = validatedData.workoutDate.split('-').map(Number)
-
-      // Create date using local timezone (not UTC)
-      // This ensures the date/time is interpreted in the user's local timezone
-      startedAt = new Date(year, month - 1, day, parseInt(hours), parseInt(minutes), 0, 0)
-
-      console.log('Local timezone components:', { year, month, day, hours, minutes })
-      console.log('Created local datetime:', startedAt)
-      console.log('Local datetime ISO:', startedAt.toISOString())
-    } else {
-      // If no time provided, use the date at noon in local timezone
-      const [year, month, day] = validatedData.workoutDate.split('-').map(Number)
-      startedAt = new Date(year, month - 1, day, 12, 0, 0, 0)
-
-      console.log('Local date with default time:', startedAt)
-      console.log('Local datetime ISO:', startedAt.toISOString())
-    }
-
-    console.log('Final datetime for DB (preserves local timezone):', startedAt.toISOString())
+    // Parse the UTC ISO string directly — the client already converted local time to UTC
+    const startedAt = new Date(validatedData.startedAtISO)
 
     // Call data helper function
     const workout = await createWorkout({
@@ -64,17 +36,12 @@ export async function createWorkoutAction(data: z.infer<typeof CreateWorkoutSche
       startedAt,
     })
 
-    console.log('Workout created:', workout)
-
     if (!workout) {
       throw new Error('Failed to create workout - no workout returned')
     }
 
-    console.log('Workout startedAt date:', workout.startedAt)
-
-    // Format date for redirect
-    const redirectDate = format(workout.startedAt, 'yyyy-MM-dd')
-    console.log('Formatted redirect date:', redirectDate)
+    // Format date for redirect using UTC date components to match what the client sent
+    const redirectDate = format(startedAt, 'yyyy-MM-dd')
 
     // Return success response with date for redirect
     return {
@@ -84,16 +51,11 @@ export async function createWorkoutAction(data: z.infer<typeof CreateWorkoutSche
     }
 
   } catch (error) {
-    console.error('Error in createWorkoutAction:', error)
-
     if (error instanceof z.ZodError) {
-      console.error('Zod errors:', error.issues)
       throw new Error(error.issues[0]?.message || 'Validation error')
     }
 
-    // Handle other errors
     const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-    console.error('Error message:', errorMessage)
     throw new Error(`Failed to create workout: ${errorMessage}`)
   }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,11 +6,12 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export function formatDateWithOrdinal(date: Date): string {
-  const day = date.getDate();
+export function formatDateWithOrdinal(date: Date | string): string {
+  const d = date instanceof Date ? date : new Date(date);
+  const day = d.getDate();
   const suffix = getOrdinalSuffix(day);
 
-  return `${day}${suffix} ${format(date, 'MMMM yyyy')}`;
+  return `${day}${suffix} ${format(d, 'MMMM yyyy')}`;
 }
 
 function getOrdinalSuffix(day: number): string {
@@ -74,7 +75,5 @@ export function parseURLDate(dateString: string): Date {
 // Format UTC timestamp for display in user's local timezone
 export function formatTimestampForDisplay(timestamp: Date | string, formatStr: string): string {
   const date = new Date(timestamp);
-  // For now, just format using the user's system timezone
-  // TODO: Add proper timezone handling when needed
   return format(date, formatStr);
 }


### PR DESCRIPTION
Two bugs were causing all dates and times to always show in UTC:

Bug 1 - Wrong UTC storage on workout creation: The server action was interpreting user time input in UTC (server timezone) instead of the user's local timezone. The client now computes a UTC ISO string via toISOString() in the browser and sends it to the server directly. The server uses new Date(startedAtISO) without any timezone math.

Bug 2 - SSR hydration mismatch on display: Client components are SSR'd on the server (UTC timezone). Added suppressHydrationWarning to all date/time display elements so React uses the client-rendered local-timezone values after hydration instead of keeping the server's UTC values.

Also updated formatDateWithOrdinal to accept Date | string safely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved hydration mismatch warnings in dashboard and workout displays to improve rendering stability.

* **Refactor**
  * Streamlined date and time handling in workout creation workflow.
  * Enhanced timestamp display flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->